### PR TITLE
Fix missing header during compilation

### DIFF
--- a/main_mandatory.c
+++ b/main_mandatory.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <fcntl.h>
 #include "../get_next_line.h"
 
 int	main(int argc, char *argv[])


### PR DESCRIPTION
fcntl.h was missing from "main_mandatory.c"

```
main_mandatory.c: In function ‘main’:
main_mandatory.c:11:26: error: implicit declaration of function ‘open’; did you mean ‘popen’? [-Werror=implicit-function-declaration]
   11 |  if ((fd = (argc == 2) ? open(argv[1], O_RDONLY) : 0) == -1)
      |                          ^~~~
      |                          popen
main_mandatory.c:11:40: error: ‘O_RDONLY’ undeclared (first use in this function)
   11 |  if ((fd = (argc == 2) ? open(argv[1], O_RDONLY) : 0) == -1)
      |                                        ^~~~~~~~
main_mandatory.c:11:40: note: each undeclared identifier is reported only once for each function it appears in
cc1: all warnings being treated as errors
```